### PR TITLE
Upgrade to Swift 6, GRDB 7.9.0, and Swift Argument Parser 1.6.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,15 +6,15 @@ import PackageDescription
 let package = Package(
     name: "gtfs-importer",
     platforms: [
-        .macOS(SupportedPlatform.MacOSVersion.v11),
-        .iOS(SupportedPlatform.IOSVersion.v12)
+        .macOS(.v11),
+        .iOS(.v14)
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(name: "GRDB", url: "https://github.com/groue/GRDB.swift.git", from: "6.29.1"),
-        .package(url: "https://github.com/yaslab/CSV.swift.git", .upToNextMinor(from: "2.4.3")),
-        .package(url: "https://github.com/jogi/GTFSModel", .branch("main"))
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.6.2"),
+        .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.9.0"),
+        .package(url: "https://github.com/yaslab/CSV.swift.git", .upToNextMinor(from: "2.5.2")),
+        .package(url: "https://github.com/jogi/GTFSModel", branch: "upgrade-swift6-grdb7")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -24,7 +24,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "CSV", package: "CSV.swift"),
-                "GRDB",
+                .product(name: "GRDB", package: "GRDB.swift"),
                 "GTFSModel"
             ]),
         .testTarget(

--- a/Sources/gtfs-importer/Importing/Importer.swift
+++ b/Sources/gtfs-importer/Importing/Importer.swift
@@ -90,7 +90,7 @@ extension ImporterImporting where Self: DatabaseCreating {
 }
 
 struct Importer {
-    static var defaultDatabaseFileName = "gtfs.db"
+    static let defaultDatabaseFileName = "gtfs.db"
     var path: String
     
     func importAllFiles() throws {

--- a/Sources/gtfs-importer/Logger.swift
+++ b/Sources/gtfs-importer/Logger.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 
 extension Logger {
-    private static var subsystem = "com.jogi.gtfs-importer"
+    private static let subsystem = "com.jogi.gtfs-importer"
 
     static let importer = Logger(subsystem: subsystem, category: "importer")
 }


### PR DESCRIPTION
## Summary
- Upgrades Swift tools version from 5.3 to 6.0
- Upgrades GRDB from 6.29.1 to 7.9.0
- Upgrades Swift Argument Parser from 1.0.0 to 1.6.2
- Updates minimum platform requirements to macOS 11.0 and iOS 14.0
- Fixes Swift 6 concurrency warnings
- Depends on GTFSModel upgrade PR

## Changes

### Dependency Updates
- Swift tools version: 5.3 → 6.0
- GRDB: 6.29.1 → 7.9.0
- Swift Argument Parser: 1.0.0 → 1.6.2
- Platform minimums: macOS 11.0/iOS 12 → macOS 11.0/iOS 14.0
- GTFSModel: updated to use upgrade-swift6-grdb7 branch (temporary)

### Swift 6 Concurrency Fixes
- Changed mutable static properties (`var`) to immutable (`let`) for concurrency safety:
  - `subsystem` in Logger extension
  - `defaultDatabaseFileName` in Importer struct

### Code Quality
- Fixed deprecated `.branch()` syntax to use `branch:` parameter

## Dependencies
⚠️ **This PR depends on https://github.com/jogi/GTFSModel/pull/2**

After merging the GTFSModel PR, we should update this PR to:
- Change GTFSModel dependency from `branch: "upgrade-swift6-grdb7"` back to `branch: "main"`

## Testing
- ✅ Successfully builds with Swift 6
- ✅ All GRDB 7 requirements met
- ✅ No concurrency warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)